### PR TITLE
Fix stray code block start

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,8 +271,6 @@ notation to specify the parent tables like this:
 `authors.posts.comments`.
 
 ```bash
-
-```bash
 # Create CRUD for authors table
 $ php artisan crud:generate authors
 


### PR DESCRIPTION
This pull request aims to fix a stray bash code block in the README file of a GitHub repository. The previous version of the file contained a stray ```bash which has been removed in this proposed update.